### PR TITLE
Erweiterung Validator für Subfolder

### DIFF
--- a/lib/src/plugin/java/JavaValidator.ts
+++ b/lib/src/plugin/java/JavaValidator.ts
@@ -79,9 +79,9 @@ class JavaValidator {
   }
 
   private async checkDefinition(definition: Definition, definitionName: string | undefined): Promise<void> {
-    // File must exists, otherwise we cannot check anything anyway
-    const filename = path.join(this.getModuleDir(), getSimpleJavaClassName(this.currentSchema, definitionName) + '.java')
-    if (!await existAndAccessible(filename)) {
+    // Search for the file in the module directory and its subdirectories
+    const filename = await this.findFileInSubfolders(this.getModuleDir(), getSimpleJavaClassName(this.currentSchema, definitionName) + '.java')
+    if (!filename) {
       this.currentSchema['x-errors'].push({
         text: `'${getFullJavaClassName(this.currentSchema, this.options, definitionName)}' should exist but is missing in the implementation`,
         type: 'MISSING_IN_IMPLEMENTATION',
@@ -96,6 +96,30 @@ class JavaValidator {
     } else {
       this.checkObjectDefinition(fileContent, definition, definitionName)
     }
+  }
+
+  private async findFileInSubfolders(dir: string, targetFile: string): Promise<string | undefined> {
+    try {
+      const dirStat = await fs.stat(dir);
+      if (!dirStat.isDirectory()) {
+        return undefined;
+      }
+    } catch (err) {
+      // If the directory doesn't exist or there is an error, return undefined
+      return undefined;
+    }
+
+    const dirents = await fs.readdir(dir, { withFileTypes: true });
+    for (const dirent of dirents) {
+      const res = path.resolve(dir, dirent.name);
+      if (dirent.isDirectory()) {
+        const found = await this.findFileInSubfolders(res, targetFile);
+        if (found) return found;
+      } else if (dirent.isFile() && path.basename(res) === targetFile) {
+        return res;
+      }
+    }
+    return undefined;
   }
 
   private checkObjectDefinition(fileContent: string, definition: ObjectDefinition, definitionName: string | undefined): void {
@@ -212,8 +236,8 @@ async function existAndAccessible(file: string): Promise<boolean> {
   const exists = await fs.stat(file).then(_ => true).catch((_: unknown) => false)
   if (!exists) return false
   return await fs.access(file, fs.constants.F_OK)
-    .then(() => true)
-    .catch(() => false)
+      .then(() => true)
+      .catch(() => false)
 }
 
 function printType(type: JavaType): string {

--- a/lib/src/plugin/java/JavaValidator.ts
+++ b/lib/src/plugin/java/JavaValidator.ts
@@ -250,7 +250,8 @@ function printType(type: JavaType): string {
 
 function typesEqual(type1: JavaType, type2: JavaType): boolean {
   switch (type1.type) {
-    case 'CLASS': return type2.type === 'CLASS' && type1.fullName === type2.fullName
+      // Fullname check (incl. package) clashes when the implemenation uses subpackages, e.g. in partner module
+    case 'CLASS': return type2.type === 'CLASS' && type1.fullName.split('.').pop() === type2.fullName.split('.').pop()
     case 'COLLECTION': return type2.type === 'COLLECTION' && typesEqual(type1.items, type2.items)
     case 'MAP': return type2.type === 'MAP' && typesEqual(type1.items, type2.items)
   }

--- a/lib/src/plugin/java/JavaValidator.ts
+++ b/lib/src/plugin/java/JavaValidator.ts
@@ -249,10 +249,18 @@ function printType(type: JavaType): string {
 }
 
 function typesEqual(type1: JavaType, type2: JavaType): boolean {
-  switch (type1.type) {
-      // Fullname check (incl. package) clashes when the implemenation uses subpackages, e.g. in partner module
-    case 'CLASS': return type2.type === 'CLASS' && type1.fullName.split('.').pop() === type2.fullName.split('.').pop()
-    case 'COLLECTION': return type2.type === 'COLLECTION' && typesEqual(type1.items, type2.items)
-    case 'MAP': return type2.type === 'MAP' && typesEqual(type1.items, type2.items)
+  if (type1.type === 'CLASS') {
+    if (type2.type !== 'CLASS') return false
+    // We want to allow classes to be in sub-packages.
+    // Therefore we check if the package is a prefix of the other package and if the class name is the same
+    const type1Name = type1.fullName.split('.')
+    const type2Name = type2.fullName.split('.')
+    if (type1Name.pop() !== type2Name.pop()) return false
+    const type1Package = type1Name.join('.')
+    const type2Package = type2Name.join('.')
+    return type1Package.startsWith(type2Package) || type2Package.startsWith(type1Package)
   }
+  if (type2.type === 'CLASS') return false
+  if (type1.type !== type2.type) return false
+  return typesEqual(type1.items, type2.items)
 }


### PR DESCRIPTION
Hoi Matthias,

Anbei die Anpassungen wegen den Subfoldern. Das ist vor allem im Partner Module nötig. 

Meine Änderung bei typesEqual ist nicht soo schön 😶‍🌫️ wenn du einen besseren Vorschlag hast können wir es gerne anders machen. Nötig ist es ebenfalls wegen den Subfoldern weil der Packagepath nicht stimmt wenn die Klasse in einem Subfolder liegt. Das Domain Modell weiss natürlich nicht in welchem Subfolder die Klasse liegen muss. Ggf. könnte man den Path auch partially vergleichen.

Mögliche weitere Ergänzungen an der Lib:

- weniger verbose Ausgabe bei Diffs in der selben Klasse / Open API Spec Methode
- stabile Sortierung in den Open API Specs. (bin nicht sicher ob es aktuell instabil ist, wir hatte es im alten Generator mal erweitert)
- gewisse Objekte z.B. Projekt werden in der openapi spec mit dem Module Namen prefixed z.B. ZeiterfassungProjekt, ich bin mir nicht ganz sicher wann das passiert bzw. wieso. Im alten Generator war es jeweils nur Projekt. Falls Möglich wär es einfacher für die Migration wenn es dies nicht macht.